### PR TITLE
Rename deployment to "test", update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,17 @@
 This is a demo ROFL app that runs in TDX using Podman containers defined in a
 `compose.yaml` file. It implements a simple price oracle in a shell script!
 
-## Build
-
-To build the ROFL app and reproduce the measurements, simply run:
-
-```sh
-oasis rofl build
-```
-
-You can verify the measurements against the policy specified in `rofl.yaml` and
-published on chain by running:
-
-```sh
-oasis rofl build --verify
-```
-
 ## Documentation
 
 See [the ROFL documentation] for more details about ROFL-specific features
-available to ROFL apps and on how to deploy the apps.
+available to ROFL apps and on how to deploy the apps. See [the tutorial] on how
+to create your own version of this app.
 
 [the ROFL documentation]: https://docs.oasis.io/build/rofl
+[the tutorial]: https://docs.oasis.io/build/rofl/app
+
+## Existing Deployment
+
+The `rofl.yaml` in this repository defines an existing deployment named `test`
+that is used for testing of the demo ROFL app. If you want to modify any of the
+application aspects, you need to create your own deployment.

--- a/rofl.yaml
+++ b/rofl.yaml
@@ -19,7 +19,7 @@ artifacts:
     runtime: https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.5.0/rofl-containers#800be74e543f1d10d12ef6fadce89dd0a0ce7bc798dbab4f8d7aa012d82fbff1
     compose: compose.yaml
 deployments:
-  default:
+  test:
     app_id: rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw
     network: testnet
     paratime: sapphire


### PR DESCRIPTION
See #2 

This is a quick fix for the README. We could probably expand on how to create new deployments of this app and modify the contracts. Currently we just link to the tutorial which explains this.

The reason for renaming the deployment to `test` is that when you do any rofl-related commands, they would use the `default` deployment by default. By renaming it, we allow anyone that just copies the `rofl.yaml` to create their own deployment simply by running `oasis rofl create` (similar for other steps).